### PR TITLE
Upgrade runtime from python2.7 to python3.9

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -25,14 +25,14 @@ create_functions:
 
 	- aws lambda create-function \
 	--function-name feature-flipper-public \
-	--runtime python2.7 \
+	--runtime python3.9 \
 	--role $$(python lambda_role_arn.py) \
 	--handler lambda_function.lambda_handler \
 	--zip-file fileb://delete_me.zip
 
 	- aws lambda create-function \
 	--function-name feature-flipper-private \
-	--runtime python2.9 \
+	--runtime python3.9 \
 	--role $$(python lambda_role_arn.py) \
 	--handler lambda_function.lambda_handler \
 	--zip-file fileb://delete_me.zip

--- a/server/Makefile
+++ b/server/Makefile
@@ -32,7 +32,7 @@ create_functions:
 
 	- aws lambda create-function \
 	--function-name feature-flipper-private \
-	--runtime python2.7 \
+	--runtime python2.9 \
 	--role $$(python lambda_role_arn.py) \
 	--handler lambda_function.lambda_handler \
 	--zip-file fileb://delete_me.zip

--- a/server/deploy.dockerfile
+++ b/server/deploy.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.11
+FROM python:3.9.12
 
 RUN apt-get -y update
 RUN apt-get -y install zip

--- a/server/private/lambda_function.py
+++ b/server/private/lambda_function.py
@@ -33,10 +33,10 @@ DEFAULT_SET = {
 def lambda_handler(req, context):
     try:
         return handle_request(req)
-    except HTTPError, e:
+    except HTTPError as e:
         traceback.print_exc()
         raise e
-    except Exception, e:
+    except Exception as e:
         traceback.print_exc()
         s500()
 
@@ -49,7 +49,7 @@ def handle_request(req):
     if 'resource_path' not in req:
         s400()
 
-    print(req['http_method'] + ' ' + req['resource_path'])
+    print('v2: ' + req['http_method'] + ' ' + req['resource_path'])
     if req['http_method'] == "GET":
 
         if req['resource_path'] == "/set/{set_id}":

--- a/server/public/lambda_function.py
+++ b/server/public/lambda_function.py
@@ -25,10 +25,10 @@ DB_ALIAS_TABLE = 'FeatureFlipperAliases'
 def lambda_handler(req, context):
     try:
         return handle_request(req)
-    except HTTPError, e:
+    except HTTPError as e:
         traceback.print_exc()
         raise e
-    except Exception, e:
+    except Exception as e:
         traceback.print_exc()
         s500()
 
@@ -41,7 +41,7 @@ def handle_request(req):
     if 'resource_path' not in req:
         s400()
 
-    print(req['http_method'] + ' ' + req['resource_path'])
+    print('v2: ' + req['http_method'] + ' ' + req['resource_path'])
     if req['http_method'] == "GET":
 
         if req['resource_path'] == "/sets":
@@ -206,7 +206,8 @@ def get_feature_set_data(setId):
     if 'Item' in getDataRes:
         item = getDataRes['Item']
         if 'Data' in item and 'B' in item['Data']:
-            featureData = msgpack.loads(item['Data']['B'])
+            featureData = msgpack.loads(item['Data']['B'], encoding='utf-8')
+            print(featureData)
             return featureData
         else:
             return {}

--- a/server/virtualenv.cmd
+++ b/server/virtualenv.cmd
@@ -3,7 +3,7 @@
 rm -fr /host/virtualenv
 mkdir /host/virtualenv
 mkdir ve
-virtualenv ve
+python -m venv ve
 source ve/bin/activate
 pip install msgpack-python
 cp -R /ve/lib/python3.9/site-packages/* /host/virtualenv

--- a/server/virtualenv.cmd
+++ b/server/virtualenv.cmd
@@ -6,4 +6,4 @@ mkdir ve
 virtualenv ve
 source ve/bin/activate
 pip install msgpack-python
-cp -R /ve/lib/python2.7/site-packages/* /host/virtualenv
+cp -R /ve/lib/python3.9/site-packages/* /host/virtualenv

--- a/server/virtualenv.dockerfile
+++ b/server/virtualenv.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.11
+FROM python:3.9.12
 
 ADD virtualenv.cmd /
 


### PR DESCRIPTION
AWS announced end of support for Python2.7. This PR includes changes required to migrate Python 2.7 to Python 3.7.